### PR TITLE
Fix Add Stamp modal labels and styling

### DIFF
--- a/src/StampManager.js
+++ b/src/StampManager.js
@@ -229,8 +229,8 @@ class StampManager {
             <h3>Add New Stamp</h3>
             <form id="add-stamp-form">
                 <div class="form-group">
-                    <label for="stamp-name">Name:</label>
-                    <input type="text" id="stamp-name" required>
+                    <label for="stamp-name">Stamp Name:</label>
+                    <input type="text" id="stamp-name" placeholder="Enter stamp name (e.g., 'Christmas 2024')" required>
                 </div>
                 <div class="form-group">
                     <label for="stamp-currency">Currency:</label>
@@ -240,13 +240,14 @@ class StampManager {
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="stamp-value">Value:</label>
-                    <input type="number" id="stamp-value" step="0.01" min="0.01" required>
+                    <label for="stamp-value">Value (€):</label>
+                    <input type="number" id="stamp-value" step="0.01" min="0.01" placeholder="0.00" required>
                     <small id="currency-hint">Enter value in selected currency</small>
                 </div>
                 <div class="form-group">
                     <label for="stamp-quantity">Quantity:</label>
-                    <input type="number" id="stamp-quantity" min="1" value="1" required>
+                    <input type="number" id="stamp-quantity" min="1" value="1" placeholder="1" required>
+                    <small>Number of stamps to add to collection</small>
                 </div>
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary">Add Stamp</button>
@@ -282,16 +283,18 @@ class StampManager {
             <h3>Add New Postage Rate</h3>
             <form id="add-rate-form">
                 <div class="form-group">
-                    <label for="rate-name">Name:</label>
-                    <input type="text" id="rate-name" required>
+                    <label for="rate-name">Rate Name:</label>
+                    <input type="text" id="rate-name" placeholder="Enter rate name (e.g., 'Standard Letter')" required>
                 </div>
                 <div class="form-group">
                     <label for="rate-value">Rate (€):</label>
-                    <input type="number" id="rate-value" step="0.01" min="0.01" required>
+                    <input type="number" id="rate-value" step="0.01" min="0.01" placeholder="0.00" required>
+                    <small>Postage cost in euros</small>
                 </div>
                 <div class="form-group">
                     <label for="rate-weight">Max Weight (grams):</label>
-                    <input type="number" id="rate-weight" min="1" value="20" required>
+                    <input type="number" id="rate-weight" min="1" value="20" placeholder="20" required>
+                    <small>Maximum weight for this postage rate</small>
                 </div>
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary">Add Rate</button>

--- a/src/style.css
+++ b/src/style.css
@@ -209,14 +209,16 @@ button:focus-visible {
   padding: 8px 16px;
   border: 1px solid #d1d5db;
   border-radius: 6px;
-  background: white;
+  background: #f8f9fa;
+  color: #374151;
   cursor: pointer;
   font-size: 14px;
   transition: all 0.3s ease;
 }
 
 .btn:hover {
-  background-color: #f8f9fa;
+  background-color: #e5e7eb;
+  border-color: #9ca3af;
 }
 
 .btn-primary {
@@ -281,7 +283,19 @@ button:focus-visible {
   border-radius: 8px;
   width: 90%;
   max-width: 500px;
+  min-width: 400px;
   position: relative;
+  color: #374151;
+  box-sizing: border-box;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-content h3 {
+  margin-top: 0;
+  margin-bottom: 20px;
+  color: #1f2937;
+  font-size: 18px;
 }
 
 .close {
@@ -298,26 +312,62 @@ button:focus-visible {
 
 .form-group {
   margin-bottom: 16px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.modal-content form {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .form-group label {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
+  color: #374151;
+  font-size: 14px;
 }
 
-.form-group input {
+.form-group input,
+.form-group select {
   width: 100%;
   padding: 8px 12px;
   border: 1px solid #d1d5db;
   border-radius: 4px;
   font-size: 14px;
+  background-color: white;
+  box-sizing: border-box;
 }
 
-.form-group input:focus {
+.form-group select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 16px;
+  padding-right: 32px;
+}
+
+.form-group input:focus,
+.form-group select:focus {
   outline: none;
   border-color: #007bff;
   box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.form-group small {
+  display: block;
+  margin-top: 4px;
+  color: #6b7280;
+  font-size: 12px;
+  font-style: italic;
+}
+
+.form-group input::placeholder,
+.form-group select::placeholder {
+  color: #9ca3af;
+  font-style: italic;
 }
 
 .form-actions {
@@ -325,4 +375,28 @@ button:focus-visible {
   gap: 12px;
   justify-content: flex-end;
   margin-top: 20px;
+  width: 100%;
+  box-sizing: border-box;
+  flex-wrap: wrap;
+}
+
+.form-actions .btn {
+  min-width: 80px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+  .form-actions {
+    justify-content: stretch;
+  }
+  
+  .form-actions .btn {
+    flex: 1;
+  }
+  
+  .modal-content {
+    width: 95%;
+    min-width: 280px;
+    padding: 16px;
+  }
 }


### PR DESCRIPTION
## Problem
The Add Stamp modal had several UI issues:
- Input fields had no clear labels or explanatory text
- Currency dropdown didn't look like a dropdown (missing arrow)
- Cancel button was invisible (white on white background)
- Form inputs were overflowing on smaller screens

## Solution
- ✅ Added clear, descriptive labels for all form inputs
- ✅ Added placeholder text and help hints for better user guidance
- ✅ Fixed dropdown styling with proper arrow icon and appearance
- ✅ Improved button visibility with proper background colors
- ✅ Added responsive design for mobile/smaller screens
- ✅ Enhanced form layout to prevent overflow issues

## Testing
- All existing tests pass
- Modal now displays properly with visible labels and buttons
- Dropdown appears as expected with selection arrow
- Form is responsive and works on different screen sizes

## Screenshots
The modal now clearly shows:
- 'Stamp Name:' with placeholder text
- 'Currency:' dropdown with proper styling
- 'Value (€):' with currency hints
- 'Quantity:' with help text
- Visible 'Add Stamp' and 'Cancel' buttons